### PR TITLE
Removed uneeded struct bounds in states.

### DIFF
--- a/src/character/components/states.rs
+++ b/src/character/components/states.rs
@@ -1,26 +1,36 @@
 use crate::character::state::components::BulletSpawn;
 use crate::character::state::State;
-use crate::typedefs::HashId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct States<Id, ParticleId, BulletInfo, AttackId>
-where
-    Id: HashId,
-    ParticleId: HashId,
-    BulletInfo: Default,
-{
+#[derive(Serialize, Deserialize)]
+pub struct States<Id, ParticleId, BulletSpawnInfo, AttackId> {
     #[serde(flatten)]
-    pub rest: HashMap<String, State<Id, ParticleId, BulletInfo, AttackId>>,
+    #[serde(bound(
+        serialize = "HashMap<String, State<Id, ParticleId, BulletSpawnInfo, AttackId>>: Serialize",
+        deserialize = "HashMap<String, State<Id, ParticleId, BulletSpawnInfo, AttackId>>: Deserialize<'de>"
+    ))]
+    pub rest: HashMap<String, State<Id, ParticleId, BulletSpawnInfo, AttackId>>,
     #[serde(skip)]
     _secret: (),
 }
 
+impl<Id, ParticleId, BulletSpawnInfo, AttackId> std::fmt::Debug
+    for States<Id, ParticleId, BulletSpawnInfo, AttackId>
+where
+    HashMap<String, State<Id, ParticleId, BulletSpawnInfo, AttackId>>: std::fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        let mut builder = fmt.debug_struct("States");
+        let _ = builder.field("rest", &self.rest);
+        builder.finish()
+    }
+}
+
 pub type EditorStates = States<String, String, BulletSpawn, String>;
 
-impl<Id: HashId, ParticleId: HashId, BulletInfo: Eq + Default, AttackId: HashId>
-    States<Id, ParticleId, BulletInfo, AttackId>
+impl<Id, ParticleId, BulletSpawnInfo: Eq + Default, AttackId>
+    States<Id, ParticleId, BulletSpawnInfo, AttackId>
 {
     pub fn new() -> Self {
         Self {
@@ -29,7 +39,7 @@ impl<Id: HashId, ParticleId: HashId, BulletInfo: Eq + Default, AttackId: HashId>
         }
     }
 
-    pub fn get_state(&self, key: &str) -> &State<Id, ParticleId, BulletInfo, AttackId> {
+    pub fn get_state(&self, key: &str) -> &State<Id, ParticleId, BulletSpawnInfo, AttackId> {
         match key {
             _ => &self.rest[key],
         }
@@ -37,7 +47,7 @@ impl<Id: HashId, ParticleId: HashId, BulletInfo: Eq + Default, AttackId: HashId>
     pub fn replace_state(
         &mut self,
         key: String,
-        data: State<Id, ParticleId, BulletInfo, AttackId>,
+        data: State<Id, ParticleId, BulletSpawnInfo, AttackId>,
     ) {
         match key.as_str() {
             _ => {

--- a/src/character/state/file.rs
+++ b/src/character/state/file.rs
@@ -1,18 +1,20 @@
 use super::State;
 use crate::assets::Assets;
 use crate::graphics::Animation;
-use crate::typedefs::{FgSerializable, StateId};
 use ggez::GameError;
 use ggez::{Context, GameResult};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fs::File;
+use std::hash::Hash;
 use std::io::BufReader;
 use std::path::PathBuf;
 
 pub fn load_from_json<
-    Id: StateId,
-    ParticleId: StateId,
-    BulletSpawnInfo: FgSerializable,
-    AttackId: StateId,
+    Id: DeserializeOwned + Serialize + Eq + Hash + Default,
+    ParticleId: DeserializeOwned + Serialize + Default,
+    BulletSpawnInfo: DeserializeOwned + Serialize + Default,
+    AttackId: DeserializeOwned + Serialize + Default,
 >(
     ctx: &mut Context,
     assets: &mut Assets,
@@ -26,12 +28,7 @@ pub fn load_from_json<
     State::load(ctx, assets, &mut state, &name, path)?;
     Ok(state)
 }
-pub fn load<
-    Id: StateId,
-    ParticleId: StateId,
-    BulletSpawnInfo: FgSerializable,
-    AttackId: StateId,
->(
+pub fn load<Id, ParticleId, BulletSpawnInfo, AttackId>(
     ctx: &mut Context,
     assets: &mut Assets,
     state: &mut State<Id, ParticleId, BulletSpawnInfo, AttackId>,
@@ -45,10 +42,10 @@ pub fn load<
     Ok(())
 }
 pub fn save<
-    Id: StateId,
-    ParticleId: StateId,
-    BulletSpawnInfo: FgSerializable,
-    AttackId: StateId,
+    Id: Serialize + Eq + Hash,
+    ParticleId: Serialize,
+    BulletSpawnInfo: Serialize,
+    AttackId: Serialize,
 >(
     ctx: &mut Context,
     assets: &mut Assets,

--- a/src/roster/generic_character/move_id.rs
+++ b/src/roster/generic_character/move_id.rs
@@ -1,6 +1,4 @@
-use crate::typedefs::StateId;
-
-pub trait GenericMoveId: StateId + Clone + Copy {
+pub trait GenericMoveId: Clone + Copy {
     const STARTING_STATE: Self;
     const HITSTUN_AIR_START: Self;
     const HITSTUN_STAND_START: Self;

--- a/src/roster/generic_character/particle_id.rs
+++ b/src/roster/generic_character/particle_id.rs
@@ -1,5 +1,3 @@
-use crate::typedefs::StateId;
-
-pub trait GenericParticleId: StateId + Clone + Copy {
+pub trait GenericParticleId: Clone + Copy {
     const ON_HIT: Self;
 }

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -33,19 +33,3 @@ pub mod collision {
         }
     }
 }
-
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::hash::Hash;
-
-pub trait HashId: Eq + Hash + Default {}
-
-pub trait StateId: Eq + Hash + Default + Serialize + DeserializeOwned {}
-
-pub trait FgSerializable: Default + Serialize + DeserializeOwned {}
-
-impl<T> HashId for T where T: Eq + Hash + Default {}
-
-impl<T> StateId for T where T: Eq + Hash + Default + Serialize + DeserializeOwned {}
-
-impl<T> FgSerializable for T where T: Default + Serialize + DeserializeOwned {}


### PR DESCRIPTION
To simplify some of the struct code, struct bounds have been replaced
with serde(bound) and manual impls of required derive-traits that
couldn't be implemented without the strait bounds automatically.